### PR TITLE
Potential issues with Vim colorschemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker | | 0 | | doesn't run / says not installed
 npm | | 4 | | some packages fail due to permissions
 ssh | | 4 | | ssh -i works
 lynx | | 5 | | seems to work entirely
-vim | | 3 | | Will open and edit Window files it cannot create new files
+vim | | 3 | | Will open and edit Window files it cannot create new files. Issues with colorschemes.
 vsftpd | | 3 | ? | Not installed with apt
 ping | | 0 | | Fails with `ping: icmp open socket: Socket type not supported`
 


### PR DESCRIPTION
I've encountered various issues trying to get colorschemes to work in vim. Not sure if this is a personal configuration issue or an issue with the WSL. I've tried doing a full re-install of vim and all of its dependencies from apt-get and have had no luck.

If anyone has been able to get these to work, are there any particular configuration steps that you've had to take?
