### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ R | r-base  | 4 | | devtools, doParallel and foreach works. May be numerically a
 rbenv | | 4 | | works for the most part, but permissions of folders are wrong after installing (world writable), spawning warnings when running e.g. Rubygems | 14366
 reboot | | 0 | | Unable to shutdown system.
 rsync | | 4 | | works with ssh tunneling and with same file system. Needs more testing
-ruby | | 5 | | works for Sinatra and Rails development using C extension gems | 14366
+ruby | | 4 | | works for Sinatra and Rails development using C extension gems for the most part, but `rails new testapp` works with `WeBrick` (the default), but hangs with `thin` | 14986
 rustc | | 4 | [rust-lang.org](https://www.rust-lang.org/downloads.html) | Can compile basic programs. Needs testing with more complex programs | 14393.67
 scp | | 5 | | works for both remote to local and local to remote transfers.
 screen | | 0 | | Already installed. Gives permission denied if not sudouser and doesn't start if given permissions


### PR DESCRIPTION
The current declaration that ruby works with full functionality (5) is a bit misleading, at least on the newest build (14986). For example, a new rails server (e.g. with `rails new testapp; cd testapp; rails s`) does seem to work. but if you edit the Gemfile to use the `thin` server instead of the default `WeBrick` it hangs. Others seem to have seen this as well, although I dont see a solution offered other than referring to it as a possible "problem with Thin"
